### PR TITLE
FCNs support

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -41,7 +41,7 @@ def main():
                 src_out.write(transformer.transform_source())
         logger.info('Done.')
     except KaffeError as err:
-        logger.info('Error encountered: %s'%err)
+        logger.info('Error encountered: %s' % err)
         exit(-1)
 
     logger.info("finished running %s", program)

--- a/convert.py
+++ b/convert.py
@@ -1,12 +1,26 @@
 #!/usr/bin/env python
 
-import numpy as np
+import sys
+import os
+import logging
 import argparse
+
+import numpy as np
+
 from kaffe import KaffeError
 from kaffe.tensorflow import TensorFlowTransformer
 
 
+logger = logging.getLogger(__name__)
+
+
 def main():
+    logging.basicConfig(
+        format='%(asctime)s : %(levelname)s : %(module)s:%(funcName)s:%(lineno)d : %(message)s',
+        level=logging.DEBUG)
+    logger.info("running %s", " ".join(sys.argv))
+    program = os.path.basename(sys.argv[0])
+
     parser = argparse.ArgumentParser()
     parser.add_argument('def_path', help='Model definition (.prototxt) path')
     parser.add_argument('data_path', help='Model data (.caffemodel) path')
@@ -16,19 +30,22 @@ def main():
     args = parser.parse_args()
     try:
         transformer = TensorFlowTransformer(args.def_path, args.data_path, phase=args.phase)
-        print('Converting data...')
+        logger.info('Converting data...')
         data = transformer.transform_data()
-        print('Saving data...')
+        logger.info('Saving data...')
         with open(args.data_output_path, 'wb') as data_out:
             np.save(data_out, data)
         if args.code_output_path is not None:
-            print('Saving source...')
+            logger.info('Saving source...')
             with open(args.code_output_path, 'wb') as src_out:
                 src_out.write(transformer.transform_source())
-        print('Done.')
+        logger.info('Done.')
     except KaffeError as err:
-        print('Error encountered: %s'%err)
+        logger.info('Error encountered: %s'%err)
         exit(-1)
+
+    logger.info("finished running %s", program)
+
 
 if __name__ == '__main__':
     main()

--- a/convert.py
+++ b/convert.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import numpy as np
 import argparse
 from kaffe import KaffeError
 from kaffe.tensorflow import TensorFlowTransformer
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/examples/alexnet.py
+++ b/examples/alexnet.py
@@ -1,10 +1,12 @@
 from kaffe.tensorflow import Network
 
+
 class AlexNet(Network):
-    batch_size  = 500
-    scale_size  = 227
-    crop_size   = 227
-    isotropic   = True
+    batch_size = 500
+    scale_size = 227
+    crop_size = 227
+    isotropic = True
+
     def setup(self):
         (self.feed('data')
              .conv(11, 11, 96, 4, 4, padding='VALID', name='conv1')

--- a/examples/caffenet.py
+++ b/examples/caffenet.py
@@ -1,5 +1,6 @@
 from kaffe.tensorflow import Network
 
+
 class CaffeNet(Network):
     def setup(self):
         (self.feed('data')

--- a/examples/googlenet.py
+++ b/examples/googlenet.py
@@ -1,5 +1,6 @@
 from kaffe.tensorflow import Network
 
+
 class GoogleNet(Network):
     def setup(self):
         (self.feed('data')

--- a/examples/vgg.py
+++ b/examples/vgg.py
@@ -1,5 +1,6 @@
 from kaffe.tensorflow import Network
 
+
 class VGG16(Network):
     def setup(self):
         (self.feed('data')

--- a/kaffe/base.py
+++ b/kaffe/base.py
@@ -1,19 +1,21 @@
 import sys
 
+
 class KaffeError(Exception):
     pass
 
 # Ordering of the blobs
-IDX_WEIGHTS  = 0
-IDX_BIAS     = 1
+IDX_WEIGHTS = 0
+IDX_BIAS = 1
 
 # The tensors are ordered (c_o, c_i, h, w) or (n, c, h, w)
-IDX_N        = 0
-IDX_C        = 1
-IDX_C_OUT    = 0
-IDX_C_IN     = 1
-IDX_H        = 2
-IDX_W        = 3
+IDX_N = 0
+IDX_C = 1
+IDX_C_OUT = 0
+IDX_C_IN = 1
+IDX_H = 2
+IDX_W = 3
+
 
 def print_stderr(msg):
-    sys.stderr.write('%s\n'%msg)
+    sys.stderr.write('%s\n' % msg)

--- a/kaffe/core.py
+++ b/kaffe/core.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import numpy as np
 from google.protobuf import text_format
 
@@ -28,16 +27,17 @@ if PYCAFFE_AVAILABLE:
         print_stderr('Failed to import dist protobuf code. Using failsafe.')
         print_stderr('Custom layers might not work.')
 
+
 class Node(object):
     def __init__(self, name, kind, layer=None):
-        self.name         = name
-        self.kind         = kind
-        self.layer        = LayerAdapter(layer, kind) if layer else None
-        self.parents      = []
-        self.children     = []
-        self.data         = None
+        self.name = name
+        self.kind = kind
+        self.layer = LayerAdapter(layer, kind) if layer else None
+        self.parents = []
+        self.children = []
+        self.data = None
         self.output_shape = None
-        self.metadata     = {}
+        self.metadata = {}
 
     def add_parent(self, parent_node):
         assert parent_node not in self.parents
@@ -100,6 +100,7 @@ class Graph(object):
         unsorted_nodes = list(self.nodes)
         temp_marked = set()
         perm_marked = set()
+
         def visit(node):
             if node in temp_marked:
                 raise KaffeError('Graph is not a DAG.')
@@ -132,6 +133,7 @@ class Graph(object):
             s.append('{:<20} {:<30} {:>20} {:>20}'.format(node.kind,
                 node.name, data_shape, out_shape))
         return '\n'.join(s)
+
 
 class DataInjector(object):
     def __init__(self, def_path, data_path):
@@ -166,10 +168,10 @@ class DataInjector(object):
                 dims = blob.shape.dim
                 c_o, c_i, h, w = map(int, [1]*(4-len(dims))+list(dims))
             else:
-                c_o  = blob.num
-                c_i  = blob.channels
-                h    = blob.height
-                w    = blob.width
+                c_o = blob.num
+                c_i = blob.channels
+                h = blob.height
+                w = blob.width
             data = np.array(blob.data, dtype=np.float32).reshape(c_o, c_i, h, w)
             transformed.append(data)
         return transformed
@@ -183,9 +185,9 @@ class DataInjector(object):
         # potential for future issues.
         # The Caffe-backend does not suffer from this problem.
         data = list(data)
-        squeeze_indices = [1] # Squeeze biases.
-        if node.kind==NodeKind.InnerProduct:
-            squeeze_indices.append(0) # Squeeze FC.
+        squeeze_indices = [1]  # Squeeze biases.
+        if node.kind == NodeKind.InnerProduct:
+            squeeze_indices.append(0)  # Squeeze FC.
         for idx in squeeze_indices:
             data[idx] = np.squeeze(data[idx])
         return data
@@ -197,6 +199,7 @@ class DataInjector(object):
                 node.data = self.adjust_parameters(node, data)
             else:
                 print_stderr('Ignoring parameters for non-existent layer: %s'%layer_name)
+
 
 class DataReshaper(object):
     def __init__(self, mapping):
@@ -215,7 +218,7 @@ class DataReshaper(object):
         try:
             parent = node.get_only_parent()
             s = parent.output_shape
-            return (s[IDX_H]>1 or s[IDX_W]>1)
+            return s[IDX_H] > 1 or s[IDX_W] > 1
         except KaffeError:
             return False
 

--- a/kaffe/core.py
+++ b/kaffe/core.py
@@ -52,8 +52,8 @@ class Node(object):
             child_node.parents.append(self)
 
     def get_only_parent(self):
-        if len(self.parents)!=1:
-            raise KaffeError('Node (%s) expected to have 1 parent. Found %s.'%(self, len(self.parents)))
+        if len(self.parents) != 1:
+            raise KaffeError('Node (%s) expected to have 1 parent. Found %s.' % (self, len(self.parents)))
         return self.parents[0]
 
     @property
@@ -68,15 +68,16 @@ class Node(object):
         return self.data[IDX_WEIGHTS].shape
 
     def __str__(self):
-        return '[%s] %s'%(self.kind, self.name)
+        return '[%s] %s' % (self.kind, self.name)
 
     def __repr__(self):
-        return '%s (0x%x)'%(self.name, id(self))
+        return '%s (0x%x)' % (self.name, id(self))
+
 
 class Graph(object):
     def __init__(self, nodes=None, name=None):
         self.nodes = nodes or []
-        self.node_lut = {node.name:node for node in self.nodes}
+        self.node_lut = {node.name: node for node in self.nodes}
         self.name = name
 
     def add_node(self, node):
@@ -185,10 +186,16 @@ class DataInjector(object):
         # potential for future issues.
         # The Caffe-backend does not suffer from this problem.
         data = list(data)
+        logger.debug("data length:", len(data))
         squeeze_indices = [1]  # Squeeze biases.
         if node.kind == NodeKind.InnerProduct:
             squeeze_indices.append(0)  # Squeeze FC.
         for idx in squeeze_indices:
+            logger.debug("index %s", idx)
+            logger.debug("data length %s", len(data))
+            logger.debug("data shape %s", data[0].shape)
+            logger.debug("data idx shape %s", data[idx].shape)
+            # logger.debug(data[idx])
             data[idx] = np.squeeze(data[idx])
         return data
 
@@ -196,9 +203,10 @@ class DataInjector(object):
         for layer_name, data in self.params:
             if layer_name in graph:
                 node = graph.get_node(layer_name)
+                logger.debug(layer_name)
                 node.data = self.adjust_parameters(node, data)
             else:
-                print_stderr('Ignoring parameters for non-existent layer: %s'%layer_name)
+                print_stderr('Ignoring parameters for non-existent layer: %s' % layer_name)
 
 
 class DataReshaper(object):
@@ -209,7 +217,7 @@ class DataReshaper(object):
         try:
             return self.mapping[ndim]
         except KeyError:
-            raise KaffeError('Ordering not found for %d dimensional tensor.'%ndim)
+            raise KaffeError('Ordering not found for %d dimensional tensor.' % ndim)
 
     def transpose(self, data):
         return data.transpose(self.map(data.ndim))

--- a/kaffe/core.py
+++ b/kaffe/core.py
@@ -358,6 +358,7 @@ class GraphBuilder(object):
             DataInjector(self.def_path, self.data_path).inject(graph)
         return graph
 
+
 class NodeMapper(NodeDispatch):
     def __init__(self, graph):
         self.graph = graph
@@ -371,15 +372,15 @@ class NodeMapper(NodeDispatch):
         input_nodes = self.graph.get_input_nodes()
         nodes = [t for t in nodes if t not in input_nodes]
         # Remove implicit nodes.
-        nodes = [t for t in nodes if t.kind!=NodeKind.Implicit]
+        nodes = [t for t in nodes if t.kind != NodeKind.Implicit]
         # Decompose DAG into chains.
         chains = []
         for node in nodes:
             attach_to_chain = None
-            if len(node.parents)==1:
+            if len(node.parents) == 1:
                 parent = node.get_only_parent()
                 for chain in chains:
-                    if chain[-1]==parent:
+                    if chain[-1] == parent:
                         # Node is part of an existing chain.
                         attach_to_chain = chain
                         break

--- a/kaffe/core.py
+++ b/kaffe/core.py
@@ -6,6 +6,8 @@ from .layers import *
 from .core import print_stderr
 
 try:
+    import matplotlib
+    matplotlib.use('Agg')
     import caffe
     PYCAFFE_AVAILABLE = True
 except ImportError:

--- a/kaffe/core.py
+++ b/kaffe/core.py
@@ -227,7 +227,7 @@ class DataReshaper(object):
             if node.data is None:
                 continue
             data = node.data[IDX_WEIGHTS]
-            if (node.kind==NodeKind.InnerProduct) and self.has_spatial_parent(node):
+            if (node.kind == NodeKind.InnerProduct) and self.has_spatial_parent(node):
                 # The FC layer connected to the spatial layer needs to be
                 # re-wired to match the new spatial ordering.
                 in_shape = node.get_only_parent().output_shape
@@ -245,6 +245,7 @@ class DataReshaper(object):
                     node.data[IDX_WEIGHTS] = node.reshaped_data
                     del node.reshaped_data
 
+
 class GraphBuilder(object):
     def __init__(self, def_path, data_path=None, phase='test'):
         self.def_path = def_path
@@ -258,7 +259,7 @@ class GraphBuilder(object):
             text_format.Merge(def_file.read(), self.params)
 
     def filter_layers(self, layers):
-        phase_map = {0:'train', 1:'test'}
+        phase_map = {0: 'train', 1: 'test'}
         filtered_layer_names = set()
         filtered_layers = []
         for layer in layers:
@@ -267,12 +268,12 @@ class GraphBuilder(object):
                 phase = phase_map[layer.include[0].phase]
             if len(layer.exclude):
                 phase = phase_map[1-layer.include[0].phase]
-            exclude = (phase!=self.phase)
+            exclude = (phase != self.phase)
             # Dropout layers appear in a fair number of Caffe
             # test-time networks. These are just ignored. We'll
             # filter them out here.
-            if (not exclude) and (phase=='test'):
-                exclude = (layer.type==LayerType.Dropout)
+            if (not exclude) and (phase == 'test'):
+                exclude = (layer.type == LayerType.Dropout)
             if not exclude:
                 filtered_layers.append(layer)
                 # Guard against dupes.
@@ -283,7 +284,7 @@ class GraphBuilder(object):
     def make_node(self, layer):
         kind = NodeKind.map_raw_kind(layer.type)
         if kind is None:
-            raise KaffeError('Unknown layer type encountered: %s'%layer.type)
+            raise KaffeError('Unknown layer type encountered: %s' % layer.type)
         return Node(layer.name, kind, layer=layer)
 
     def make_input_nodes(self):
@@ -294,7 +295,7 @@ class GraphBuilder(object):
         if len(nodes):
             input_dim = map(int, self.params.input_dim)
             if not input_dim:
-                if len(self.params.input_shape)>0:
+                if len(self.params.input_shape) > 0:
                     input_dim = map(int, self.params.input_shape[0].dim)
                 else:
                     raise KaffeError('Dimensions for input not specified.')
@@ -305,10 +306,10 @@ class GraphBuilder(object):
     def fuse_relus(self, nodes):
         fused_nodes = []
         for node in nodes:
-            if node.kind!=NodeKind.ReLU:
+            if node.kind != NodeKind.ReLU:
                 continue
             parent = node.get_only_parent()
-            if len(parent.children)!=1:
+            if len(parent.children) != 1:
                 # We can only fuse this ReLU if its parent's
                 # value isn't used by any other node.
                 continue
@@ -333,13 +334,13 @@ class GraphBuilder(object):
         for layer in layers:
             node = graph.get_node(layer.name)
             for parent_name in layer.bottom:
-                assert parent_name!=layer.name
+                assert parent_name != layer.name
                 parent_node = node_outputs.get(parent_name)
-                if (parent_node is None) or (parent_node==node):
+                if (parent_node is None) or (parent_node == node):
                     parent_node = graph.get_node(parent_name)
                 node.add_parent(parent_node)
             for child_name in layer.top:
-                if child_name==layer.name:
+                if child_name == layer.name:
                     continue
                 if child_name in graph:
                     # This is an "in-place operation" that overwrites an existing node.

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -118,7 +118,6 @@ class LayerAdapter(object):
         try:
             return getattr(self.layer, name)
         except AttributeError:
-            print traceback.print_exc()
             raise NodeDispatchError('Caffe parameters not found for layer kind: %s' % self.kind)
 
     @staticmethod
@@ -148,7 +147,10 @@ class LayerAdapter(object):
         s_w = self.get_kernel_value(params.stride_w, params.stride, 1, default=1)
         p_h = self.get_kernel_value(params.pad_h, params.pad, 0, default=0)
         p_w = self.get_kernel_value(params.pad_h, params.pad, 1, default=0)
-        return KernelParameters(k_h, k_w, s_h, s_w, p_h, p_w)
+        bias_term = self.get_kernel_value(params.bias_term, params.bias_term, 0, default=True)
+        if bias_term == "false":
+            bias_term = False
+        return KernelParameters(k_h, k_w, s_h, s_w, p_h, p_w, bias_term)
 
 KernelParameters = namedtuple('KernelParameters',
                               ['kernel_h',
@@ -156,4 +158,5 @@ KernelParameters = namedtuple('KernelParameters',
                                'stride_h',
                                'stride_w',
                                'pad_h',
-                               'pad_w'])
+                               'pad_w',
+                               'bias_term'])

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -122,10 +122,10 @@ class LayerAdapter(object):
         if repeated:
             if isinstance(repeated, numbers.Number):
                 return repeated
-            if len(repeated)==1:
+            if len(repeated) == 1:
                 # Same value applies to all spatial dimensions
                 return int(repeated[0])
-            assert idx<len(repeated)
+            assert idx < len(repeated)
             # Extract the value for the given spatial dimension
             return repeated[idx]
         if default is None:

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -67,7 +67,6 @@ class NodeKind(LayerType):
     def map_raw_kind(kind):
         if kind in LAYER_TYPES:
             return kind
-        return None
 
     @staticmethod
     def compute_output_shape(node):
@@ -75,7 +74,7 @@ class NodeKind(LayerType):
             val = LAYER_DESCRIPTORS[node.kind](node)
             return val
         except NotImplementedError:
-            raise KaffeError('Output shape computation not implemented for type: %s'%node.kind)
+            raise KaffeError('Output shape computation not implemented for type: %s' % node.kind)
 
 
 class NodeDispatchError(KaffeError):
@@ -98,7 +97,7 @@ class NodeDispatch(object):
         try:
             return getattr(self, name)
         except AttributeError:
-            raise NodeDispatchError('No handler found for node kind: %s (expected: %s)'%(node_kind, name))
+            raise NodeDispatchError('No handler found for node kind: %s (expected: %s)' % (node_kind, name))
 
 
 class LayerAdapter(object):
@@ -113,7 +112,7 @@ class LayerAdapter(object):
         try:
             return getattr(self.layer, name)
         except AttributeError:
-            raise NodeDispatchError('Caffe parameters not found for layer kind: %s'%(self.kind))
+            raise NodeDispatchError('Caffe parameters not found for layer kind: %s' % self.kind)
 
     @staticmethod
     def get_kernel_value(scalar, repeated, idx, default=None):

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -3,61 +3,64 @@ import numbers
 from .shapes import *
 from collections import namedtuple
 
-LAYER_DESCRIPTORS =  {
+LAYER_DESCRIPTORS = {
 
     # Caffe Types
-    'AbsVal'                    : shape_identity,
-    'Accuracy'                  : shape_scalar,
-    'ArgMax'                    : shape_not_implemented,
-    'BNLL'                      : shape_not_implemented,
-    'Concat'                    : shape_concat,
-    'ContrastiveLoss'           : shape_scalar,
-    'Convolution'               : shape_convolution,
-    'Deconvolution'             : shape_not_implemented,
-    'Data'                      : shape_data,
-    'Dropout'                   : shape_identity,
-    'DummyData'                 : shape_data,
-    'EuclideanLoss'             : shape_scalar,
-    'Eltwise'                   : shape_identity,
-    'Exp'                       : shape_identity,
-    'Flatten'                   : shape_not_implemented,
-    'HDF5Data'                  : shape_data,
-    'HDF5Output'                : shape_identity,
-    'HingeLoss'                 : shape_scalar,
-    'Im2col'                    : shape_not_implemented,
-    'ImageData'                 : shape_data,
-    'InfogainLoss'              : shape_scalar,
-    'InnerProduct'              : shape_inner_product,
-    'Input'                     : shape_data,
-    'LRN'                       : shape_identity,
-    'MemoryData'                : shape_mem_data,
-    'MultinomialLogisticLoss'   : shape_scalar,
-    'MVN'                       : shape_not_implemented,
-    'Pooling'                   : shape_pool,
-    'Power'                     : shape_identity,
-    'ReLU'                      : shape_identity,
-    'Sigmoid'                   : shape_identity,
-    'SigmoidCrossEntropyLoss'   : shape_scalar,
-    'Silence'                   : shape_not_implemented,
-    'Softmax'                   : shape_identity,
-    'SoftmaxWithLoss'           : shape_scalar,
-    'Split'                     : shape_not_implemented,
-    'Slice'                     : shape_not_implemented,
-    'TanH'                      : shape_identity,
-    'WindowData'                : shape_not_implemented,
-    'Threshold'                 : shape_identity,
+    'AbsVal': shape_identity,
+    'Accuracy': shape_scalar,
+    'ArgMax': shape_not_implemented,
+    'BNLL': shape_not_implemented,
+    'Concat': shape_concat,
+    'ContrastiveLoss': shape_scalar,
+    'Convolution': shape_convolution,
+    'Crop': shape_not_implemented,
+    'Deconvolution': shape_not_implemented,
+    'Data': shape_data,
+    'Dropout': shape_identity,
+    'DummyData': shape_data,
+    'EuclideanLoss': shape_scalar,
+    'Eltwise': shape_identity,
+    'Exp': shape_identity,
+    'Flatten': shape_not_implemented,
+    'HDF5Data': shape_data,
+    'HDF5Output': shape_identity,
+    'HingeLoss': shape_scalar,
+    'Im2col': shape_not_implemented,
+    'ImageData': shape_data,
+    'InfogainLoss': shape_scalar,
+    'InnerProduct': shape_inner_product,
+    'Input': shape_data,
+    'LRN': shape_identity,
+    'MemoryData': shape_mem_data,
+    'MultinomialLogisticLoss': shape_scalar,
+    'MVN': shape_not_implemented,
+    'Pooling': shape_pool,
+    'Power': shape_identity,
+    'ReLU': shape_identity,
+    'Sigmoid': shape_identity,
+    'SigmoidCrossEntropyLoss': shape_scalar,
+    'Silence': shape_not_implemented,
+    'Softmax': shape_identity,
+    'SoftmaxWithLoss': shape_scalar,
+    'Split': shape_not_implemented,
+    'Slice': shape_not_implemented,
+    'TanH': shape_identity,
+    'WindowData': shape_not_implemented,
+    'Threshold': shape_identity,
 
     # Internal Types
-    'Implicit'                  : shape_identity
+    'Implicit': shape_identity
 }
 
 LAYER_TYPES = LAYER_DESCRIPTORS.keys()
+
 
 def generate_layer_type_enum():
     types = {t:t for t in LAYER_TYPES}
     return type('LayerType', (), types)
 
 LayerType = generate_layer_type_enum()
+
 
 class NodeKind(LayerType):
     @staticmethod
@@ -74,12 +77,15 @@ class NodeKind(LayerType):
         except NotImplementedError:
             raise KaffeError('Output shape computation not implemented for type: %s'%node.kind)
 
-class NodeDispatchError(KaffeError): pass
+
+class NodeDispatchError(KaffeError):
+    pass
+
 
 class NodeDispatch(object):
     @staticmethod
     def get_handler_name(node_kind):
-        if len(node_kind)<=4:
+        if len(node_kind) <= 4:
             # A catch-all for things like ReLU and tanh
             return node_kind.lower()
         # Convert from CamelCase to under_scored
@@ -93,6 +99,7 @@ class NodeDispatch(object):
             return getattr(self, name)
         except AttributeError:
             raise NodeDispatchError('No handler found for node kind: %s (expected: %s)'%(node_kind, name))
+
 
 class LayerAdapter(object):
     def __init__(self, layer, kind):
@@ -139,8 +146,8 @@ class LayerAdapter(object):
 
 KernelParameters = namedtuple('KernelParameters',
                               ['kernel_h',
-                              'kernel_w',
-                              'stride_h',
-                              'stride_w',
-                              'pad_h',
-                              'pad_w'])
+                               'kernel_w',
+                               'stride_h',
+                               'stride_w',
+                               'pad_h',
+                               'pad_w'])

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -14,7 +14,7 @@ LAYER_DESCRIPTORS = {
     'Concat': shape_concat,
     'ContrastiveLoss': shape_scalar,
     'Convolution': shape_convolution,
-    'Crop': shape_not_implemented,
+    'Crop': shape_crop,
     'Deconvolution': shape_deconvolution,
     'Data': shape_data,
     'Dropout': shape_identity,

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -18,20 +18,20 @@ def get_filter_output_shape(i_h, i_w, params, round_func):
     return int(round_func(o_h)), int(round_func(o_w))
 
 
-def get_reverse_filter_output_shape(i_h, i_w, params, round_func):
+def get_reverse_filter_output_shape(i_h, i_w, params):
     """
-    Compute output shape for the reverse filter
+    Compute output shape for the reverse filter. Computation is based on:
+    https://github.com/longjon/caffe/blob/25c2e3fdc7a27ec00893bd0335ac42e53ff2c7aa/src/caffe/layers/deconv_layer.cpp#L12
 
     :param i_h: height of the input
     :param i_w: width of the input
     :param params: namedtuple KernelParameters
-    :param round_func: function to round values
 
     :return: output_height, output_width
     """
-    o_h = ((i_h + 2 * params.pad_h) * params.stride_h) + params.kernel_h - params.stride_h
-    o_w = ((i_w + 2 * params.pad_w) * params.stride_w) + params.kernel_w - params.stride_w
-    return int(round_func(o_h)), int(round_func(o_w))
+    o_h = ((i_h - 1) * params.stride_h) + params.kernel_h - 2 * params.pad_h
+    o_w = ((i_w - 1) * params.stride_w) + params.kernel_w - 2 * params.pad_w
+    return o_h, o_w
 
 
 def get_strided_kernel_output_shape(node, round_func, deconvolution=False):
@@ -41,8 +41,7 @@ def get_strided_kernel_output_shape(node, round_func, deconvolution=False):
     if deconvolution:
         o_h, o_w = get_reverse_filter_output_shape(input_shape[IDX_H],
                                                    input_shape[IDX_W],
-                                                   node.layer.kernel_parameters,
-                                                   round_func)
+                                                   node.layer.kernel_parameters)
     else:
         o_h, o_w = get_filter_output_shape(input_shape[IDX_H],
                                            input_shape[IDX_W],

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -13,8 +13,8 @@ def make_shape(n, c, h, w):
 
 
 def get_filter_output_shape(i_h, i_w, params, round_func):    
-    o_h = (i_h + 2*params.pad_h - params.kernel_h)/float(params.stride_h) + 1
-    o_w = (i_w + 2*params.pad_w - params.kernel_w)/float(params.stride_w) + 1
+    o_h = (i_h + 2 * params.pad_h - params.kernel_h)/float(params.stride_h) + 1
+    o_w = (i_w + 2 * params.pad_w - params.kernel_w)/float(params.stride_w) + 1
     return int(round_func(o_h)), int(round_func(o_w))
 
 

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -123,11 +123,23 @@ def shape_deconvolution(node):
     """
     Compute shape for the deconvolution layer.
 
-    :param node: class Node representing deconvolution layer
+    :param node: class Node representing the deconvolution layer
 
     :return: output shape of the deconvolution layer
     """
     return get_strided_kernel_output_shape(node, math.ceil, deconvolution=True)
+
+
+def shape_crop(node):
+    """
+    Compute shape for the crop layer.
+
+    :param node: class Node representing the crop layer
+
+    :return: output shape of the crop layer
+    """
+    n, c, h, w = node.parents[1].output_shape
+    return make_shape(n, c, h, w)
 
 
 def shape_pool(node):
@@ -138,5 +150,4 @@ def shape_inner_product(node):
     input_shape = node.get_only_parent().output_shape
     return make_shape(input_shape[IDX_N],
                       node.layer.parameters.num_output,
-                      1,
-                      1)
+                      1, 1)

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -1,13 +1,16 @@
 import math
 from .base import *
 
+
 def make_shape(n, c, h, w):
-    return (n, c, h, w)
+    return n, c, h, w
+
 
 def get_filter_output_shape(i_h, i_w, params, round_func):    
     o_h = (i_h + 2*params.pad_h - params.kernel_h)/float(params.stride_h) + 1
     o_w = (i_w + 2*params.pad_w - params.kernel_w)/float(params.stride_w) + 1
-    return (int(round_func(o_h)), int(round_func(o_w)))
+    return int(round_func(o_h)), int(round_func(o_w))
+
 
 def get_strided_kernel_output_shape(node, round_func):
     assert node.layer is not None
@@ -19,17 +22,21 @@ def get_strided_kernel_output_shape(node, round_func):
     params = node.layer.parameters
     has_c_o = hasattr(params, 'num_output')
     c = params.num_output if has_c_o else input_shape[IDX_C]
-    return make_shape(input_shape[IDX_N], c, o_h ,o_w)
+    return make_shape(input_shape[IDX_N], c, o_h, o_w)
+
 
 def shape_not_implemented(node):
     raise NotImplementedError
+
 
 def shape_identity(node):
     assert len(node.parents)>0
     return node.parents[0].output_shape
 
+
 def shape_scalar(node):
     return make_shape(1, 1, 1, 1)
+
 
 def shape_data(node):
     if node.output_shape:
@@ -57,6 +64,7 @@ def shape_mem_data(node):
                       params.height,
                       params.width)
 
+
 def shape_concat(node):
     axis = node.layer.parameters.axis
     output_shape = None
@@ -67,11 +75,14 @@ def shape_concat(node):
             output_shape[axis] += parent.output_shape[axis]
     return tuple(output_shape)
 
+
 def shape_convolution(node):
     return get_strided_kernel_output_shape(node, math.floor)
 
+
 def shape_pool(node):
     return get_strided_kernel_output_shape(node, math.ceil)
+
 
 def shape_inner_product(node):
     input_shape = node.get_only_parent().output_shape

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -25,16 +25,16 @@ def get_strided_kernel_output_shape(node, round_func):
     return make_shape(input_shape[IDX_N], c, o_h, o_w)
 
 
-def shape_not_implemented(node):
+def shape_not_implemented():
     raise NotImplementedError
 
 
 def shape_identity(node):
-    assert len(node.parents)>0
+    assert len(node.parents) > 0
     return node.parents[0].output_shape
 
 
-def shape_scalar(node):
+def shape_scalar():
     return make_shape(1, 1, 1, 1)
 
 

--- a/kaffe/shapes.py
+++ b/kaffe/shapes.py
@@ -25,7 +25,12 @@ def get_strided_kernel_output_shape(node, round_func):
     return make_shape(input_shape[IDX_N], c, o_h, o_w)
 
 
-def shape_not_implemented():
+def shape_not_implemented(node):
+    """
+    In case that shape is not implemented
+
+    :param node: node, it's necessary, because of the kaffe/layers.py
+    """
     raise NotImplementedError
 
 
@@ -34,7 +39,12 @@ def shape_identity(node):
     return node.parents[0].output_shape
 
 
-def shape_scalar():
+def shape_scalar(node):
+    """
+    Shape scalar
+
+    :param node: node, it's necessary, because of the kaffe/layers.py
+    """
     return make_shape(1, 1, 1, 1)
 
 

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -84,9 +84,9 @@ class Network(object):
         convolve = lambda i, k: tf.nn.conv2d_transpose(i, k, [1, o_h, o_w, c_o], [1, s_h, s_w, 1], padding=padding)
         with tf.variable_scope(name) as scope:
             kernel = self.make_var('weights', shape=[k_h, k_w, c_i, c_o])
-            biases = self.make_var('biases', [c_o])
-            conv = convolve(input, kernel)
-            return tf.reshape(tf.nn.bias_add(conv, biases), conv.get_shape().as_list(), name=scope.name)
+            # biases = self.make_var('biases', [c_o])
+            return convolve(input, kernel)
+            # return tf.reshape(tf.nn.bias_add(conv, biases), conv.get_shape().as_list(), name=scope.name)
 
     @layer
     def conv(self, input, k_h, k_w, c_o, s_h, s_w, name, relu=True, padding=DEFAULT_PADDING, group=1):

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -75,13 +75,13 @@ class Network(object):
         assert padding in ('SAME', 'VALID')
 
     @layer
-    def deconv(self, input, k_h, k_w, c_o, s_h, s_w, name, padding=DEFAULT_PADDING):
+    def deconv(self, input, k_h, k_w, c_o, s_h, s_w, o_h, o_w, name, padding=DEFAULT_PADDING):
         """
         Deconvolution network implementation in TensorFlow.
         """
         self.validate_padding(padding)
         c_i = input.get_shape()[-1]
-        convolve = lambda i, k: tf.nn.conv2d_transpose(i, k, [1, s_h, s_w, 1], padding=padding)
+        convolve = lambda i, k: tf.nn.conv2d_transpose(i, k, [1, o_h, o_w, c_o], [1, s_h, s_w, 1], padding=padding)
         with tf.variable_scope(name) as scope:
             kernel = self.make_var('weights', shape=[k_h, k_w, c_i, c_o])
             biases = self.make_var('biases', [c_o])

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -75,6 +75,20 @@ class Network(object):
         assert padding in ('SAME', 'VALID')
 
     @layer
+    def deconv(self, input, k_h, k_w, c_o, s_h, s_w, name, padding=DEFAULT_PADDING):
+        """
+        Deconvolution network implementation in TensorFlow.
+        """
+        self.validate_padding(padding)
+        c_i = input.get_shape()[-1]
+        convolve = lambda i, k: tf.nn.conv2d_transpose(i, k, [1, s_h, s_w, 1], padding=padding)
+        with tf.variable_scope(name) as scope:
+            kernel = self.make_var('weights', shape=[k_h, k_w, c_i / group, c_o])
+            biases = self.make_var('biases', [c_o])
+            conv = convolve(input, kernel)
+            return tf.reshape(tf.nn.bias_add(conv, biases), conv.get_shape().as_list(), name=scope.name)
+
+    @layer
     def conv(self, input, k_h, k_w, c_o, s_h, s_w, name, relu=True, padding=DEFAULT_PADDING, group=1):
         self.validate_padding(padding)
         c_i = input.get_shape()[-1]

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -83,7 +83,7 @@ class Network(object):
         c_i = input.get_shape()[-1]
         convolve = lambda i, k: tf.nn.conv2d_transpose(i, k, [1, s_h, s_w, 1], padding=padding)
         with tf.variable_scope(name) as scope:
-            kernel = self.make_var('weights', shape=[k_h, k_w, c_i / group, c_o])
+            kernel = self.make_var('weights', shape=[k_h, k_w, c_i, c_o])
             biases = self.make_var('biases', [c_o])
             conv = convolve(input, kernel)
             return tf.reshape(tf.nn.bias_add(conv, biases), conv.get_shape().as_list(), name=scope.name)

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -49,24 +49,24 @@ class Network(object):
                             raise
 
     def feed(self, *args):
-        assert len(args)!=0
+        assert len(args) != 0
         self.inputs = []
-        for layer in args:
-            if isinstance(layer, basestring):
+        for l in args:
+            if isinstance(l, basestring):
                 try:
-                    layer = self.layers[layer]
+                    l = self.layers[l]
                 except KeyError:
                     print self.layers.keys()
-                    raise KeyError('Unknown layer name fed: %s'%layer)
-            self.inputs.append(layer)
+                    raise KeyError('Unknown layer name fed: %s' % l)
+            self.inputs.append(l)
         return self
 
     def get_output(self):
         return self.inputs[-1]
 
     def get_unique_name(self, prefix):
-        id = sum(t.startswith(prefix) for t,_ in self.layers.items())+1
-        return '%s_%d'%(prefix, id)
+        id = sum(t.startswith(prefix) for t, _ in self.layers.items())+1
+        return '%s_%d' % (prefix, id)
 
     def make_var(self, name, shape):
         return tf.get_variable(name, shape, trainable=self.trainable)
@@ -78,18 +78,18 @@ class Network(object):
     def conv(self, input, k_h, k_w, c_o, s_h, s_w, name, relu=True, padding=DEFAULT_PADDING, group=1):
         self.validate_padding(padding)
         c_i = input.get_shape()[-1]
-        assert c_i%group==0
-        assert c_o%group==0
+        assert c_i % group == 0
+        assert c_o % group == 0
         convolve = lambda i, k: tf.nn.conv2d(i, k, [1, s_h, s_w, 1], padding=padding)
         with tf.variable_scope(name) as scope:
             kernel = self.make_var('weights', shape=[k_h, k_w, c_i/group, c_o])
             biases = self.make_var('biases', [c_o])
-            if group==1:
+            if group == 1:
                 conv = convolve(input, kernel)
             else:
                 input_groups = tf.split(3, group, input)
                 kernel_groups = tf.split(3, group, kernel)
-                output_groups = [convolve(i, k) for i,k in zip(input_groups, kernel_groups)]
+                output_groups = [convolve(i, k) for i, k in zip(input_groups, kernel_groups)]
                 conv = tf.concat(3, output_groups)
             if relu:
                 bias = tf.reshape(tf.nn.bias_add(conv, biases), conv.get_shape().as_list())
@@ -135,7 +135,7 @@ class Network(object):
     def fc(self, input, num_out, name, relu=True):
         with tf.variable_scope(name) as scope:
             input_shape = input.get_shape()
-            if input_shape.ndims==4:
+            if input_shape.ndims == 4:
                 dim = 1
                 for d in input_shape[1:].as_list():
                     dim *= d

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -9,9 +9,9 @@ def layer(op):
         # Automatically set a name if not provided.
         name = kwargs.setdefault('name', self.get_unique_name(op.__name__))
         # Figure out the layer inputs.
-        if len(self.inputs)==0:
-            raise RuntimeError('No input variables found for layer %s.'%name)
-        elif len(self.inputs)==1:
+        if len(self.inputs) == 0:
+            raise RuntimeError('No input variables found for layer %s.' % name)
+        elif len(self.inputs) == 1:
             layer_input = self.inputs[0]
         else:
             layer_input = list(self.inputs)

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -3,6 +3,7 @@ import tensorflow as tf
 
 DEFAULT_PADDING = 'SAME'
 
+
 def layer(op):
     def layer_decorated(self, *args, **kwargs):
         # Automatically set a name if not provided.
@@ -23,6 +24,7 @@ def layer(op):
         # Return self for chained calls.
         return self
     return layer_decorated
+
 
 class Network(object):
     def __init__(self, inputs, trainable=True):

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -97,9 +97,6 @@ class TensorFlowMapper(NodeMapper):
         """
         (c_o, c_i, h, w) = node.data_shape
         (kernel_params, kwargs) = self.get_kernel_params(node)
-        group = node.parameters.group
-        if group != 1:
-            kwargs['group'] = group
         assert kernel_params.kernel_h == h
         assert kernel_params.kernel_w == w
         return TensorFlowNode('deconv',

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -95,16 +95,20 @@ class TensorFlowMapper(NodeMapper):
 
         :param node: Node object
         """
-        (c_o, c_i, h, w) = node.data_shape
+        channels_output, channels_input, height, width = node.data_shape
+        batch_size, c_o, output_height, output_width = node.output_shape
         (kernel_params, kwargs) = self.get_kernel_params(node)
-        assert kernel_params.kernel_h == h
-        assert kernel_params.kernel_w == w
+        assert kernel_params.kernel_h == height
+        assert kernel_params.kernel_w == width
+        assert channels_output == c_o
         return TensorFlowNode('deconv',
                               kernel_params.kernel_h,
                               kernel_params.kernel_w,
-                              c_o,
+                              channels_output,
                               kernel_params.stride_h,
                               kernel_params.stride_w,
+                              output_height,
+                              output_width,
                               **kwargs)
 
 

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -43,15 +43,17 @@ def get_padding_type(kernel_params, input_shape, output_shape):
     https://github.com/Yangqing/caffe2/blob/master/caffe2/proto/caffe2_legacy.proto
     """
     k_h, k_w, s_h, s_w, p_h, p_w = kernel_params
-    s_o_h = np.ceil(input_shape[IDX_H]/float(s_h))
-    s_o_w = np.ceil(input_shape[IDX_W]/float(s_w))
+    s_o_h = np.ceil(input_shape[IDX_H] / float(s_h))
+    s_o_w = np.ceil(input_shape[IDX_W] / float(s_w))
     if (output_shape[IDX_H] == s_o_h) and (output_shape[IDX_W] == s_o_w):
         return 'SAME'
-    v_o_h = np.ceil((input_shape[IDX_H]-k_h+1.0)/float(s_h))
-    v_o_w = np.ceil((input_shape[IDX_W]-k_w+1.0)/float(s_w))
+    v_o_h = np.ceil((input_shape[IDX_H] - k_h + 1.0) / float(s_h))
+    v_o_w = np.ceil((input_shape[IDX_W] - k_w + 1.0) / float(s_w))
     if (output_shape[IDX_H] == v_o_h) and (output_shape[IDX_W] == v_o_w):
         return 'VALID'
-    return None
+    # Return network.DEFAULT_PADDING for case that padding is not compatible
+    # with TensorFlow
+    return network.DEFAULT_PADDING
 
 
 class TensorFlowMapper(NodeMapper):
@@ -100,8 +102,7 @@ class TensorFlowMapper(NodeMapper):
             kwargs['group'] = group
         assert kernel_params.kernel_h == h
         assert kernel_params.kernel_w == w
-        return TensorFlowNode(node,
-                              'deconv',
+        return TensorFlowNode('deconv',
                               kernel_params.kernel_h,
                               kernel_params.kernel_w,
                               c_o,

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -1,4 +1,3 @@
-import tensorflow as tf
 import numpy as np
 from . import network
 from ..base import *

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -102,8 +102,6 @@ class TensorFlowMapper(NodeMapper):
         channels_output, channels_input, height, width = node.data_shape
         batch_size, c_o, output_height, output_width = node.output_shape
         (kernel_params, kwargs) = self.get_kernel_params(node)
-        # bias term info
-        node.layer.kernel_parameters.
         assert kernel_params.kernel_h == height
         assert kernel_params.kernel_w == width
         assert channels_output == c_o

--- a/kaffe/tensorflow/transformer.py
+++ b/kaffe/tensorflow/transformer.py
@@ -4,6 +4,7 @@ from . import network
 from ..base import *
 from ..core import GraphBuilder, DataReshaper, NodeMapper
 
+
 class TensorFlowNode(object):
     def __init__(self, op, *args, **kwargs):
         self.op = op
@@ -11,37 +12,39 @@ class TensorFlowNode(object):
         self.kwargs = list(kwargs.items())
 
     def format(self, arg):
-        return "'%s'"%arg if isinstance(arg, basestring) else str(arg)
+        return "'%s'" % arg if isinstance(arg, basestring) else str(arg)
 
     def pair(self, key, value):
-        return '%s=%s'%(key, self.format(value))
+        return '%s=%s' % (key, self.format(value))
 
     def emit(self):
         args = map(self.format, self.args)
         if self.kwargs:
-            args += [self.pair(k, v) for k,v in self.kwargs]
+            args += [self.pair(k, v) for k, v in self.kwargs]
         args.append(self.pair('name', self.node.name))
         args = ', '.join(args)
-        return '%s(%s)'%(self.op, args)
+        return '%s(%s)' % (self.op, args)
+
 
 def get_padding_type(kernel_params, input_shape, output_shape):
-    '''Translates Caffe's numeric padding to one of ('SAME', 'VALID').
+    """Translates Caffe's numeric padding to one of ('SAME', 'VALID').
     Caffe supports arbitrary padding values, while TensorFlow only
     supports 'SAME' and 'VALID' modes. So, not all Caffe paddings
     can be translated to TensorFlow. There are some subtleties to
     how the padding edge-cases are handled. These are described here:
     https://github.com/Yangqing/caffe2/blob/master/caffe2/proto/caffe2_legacy.proto
-    '''
+    """
     k_h, k_w, s_h, s_w, p_h, p_w = kernel_params
     s_o_h = np.ceil(input_shape[IDX_H]/float(s_h))
     s_o_w = np.ceil(input_shape[IDX_W]/float(s_w))
-    if (output_shape[IDX_H]==s_o_h) and (output_shape[IDX_W]==s_o_w):
+    if (output_shape[IDX_H] == s_o_h) and (output_shape[IDX_W] == s_o_w):
         return 'SAME'
     v_o_h = np.ceil((input_shape[IDX_H]-k_h+1.0)/float(s_h))
     v_o_w = np.ceil((input_shape[IDX_W]-k_w+1.0)/float(s_w))
-    if (output_shape[IDX_H]==v_o_h) and (output_shape[IDX_W]==v_o_w):
+    if (output_shape[IDX_H] == v_o_h) and (output_shape[IDX_W] == v_o_w):
         return 'VALID'
     return None
+
 
 class TensorFlowMapper(NodeMapper):
 
@@ -50,13 +53,13 @@ class TensorFlowMapper(NodeMapper):
         input_shape = node.get_only_parent().output_shape
         padding = get_padding_type(kernel_params, input_shape, node.output_shape)
         # Only emit the padding if it's not the default value.
-        padding = {'padding':padding} if padding!=network.DEFAULT_PADDING else {}
-        return (kernel_params, padding)
+        padding = {'padding': padding} if padding != network.DEFAULT_PADDING else {}
+        return kernel_params, padding
 
     def relu_adapted_node(self, node, *args, **kwargs):
         # Opt-out instead of opt-in as ReLU(op) is the common case.
         if not node.metadata.get('relu', False):
-            kwargs['relu']=False
+            kwargs['relu'] = False
         return TensorFlowNode(*args, **kwargs)
 
     def map_convolution(self, node):
@@ -65,8 +68,8 @@ class TensorFlowMapper(NodeMapper):
         group = node.parameters.group
         if group!=1:
             kwargs['group'] = group
-        assert kernel_params.kernel_h==h
-        assert kernel_params.kernel_w==w
+        assert kernel_params.kernel_h == h
+        assert kernel_params.kernel_w == w
         return self.relu_adapted_node(node,
                                       'conv',
                                       kernel_params.kernel_h,
@@ -81,9 +84,9 @@ class TensorFlowMapper(NodeMapper):
 
     def map_pooling(self, node):
         pool_type = node.parameters.pool
-        if pool_type==0:
+        if pool_type == 0:
             pool_op = 'max_pool'
-        elif pool_type==1:
+        elif pool_type == 1:
             pool_op = 'avg_pool'
         else:
             # Stochastic pooling, for instance.
@@ -109,7 +112,7 @@ class TensorFlowMapper(NodeMapper):
         params = node.parameters
         # The window size must be an odd value. For a window
         # size of (2*n+1), TensorFlow defines depth_radius = n.
-        assert (params.local_size%2==1)
+        assert (params.local_size % 2 == 1)
         # Caffe scales by (alpha/(2*n+1)), whereas TensorFlow
         # just scales by alpha (as does Krizhevsky's paper).
         # We'll account for that here.
@@ -128,6 +131,7 @@ class TensorFlowMapper(NodeMapper):
 
     def commit(self, chains):
         return chains
+
 
 class TensorFlowEmitter(object):
 
@@ -176,7 +180,7 @@ class TensorFlowEmitter(object):
             for node in chain:
                 b += self.emit_node(node)
             blocks.append(b[:-1]+')')
-        s = s + '\n\n'.join(blocks)
+        s += '\n\n'.join(blocks)
         return s
 
 
@@ -201,10 +205,10 @@ class TensorFlowTransformer(object):
     def transform_data(self):
         # Cache the graph source before mutating it.
         self.transform_source()
-        mapping = {4 : (2, 3, 1, 0), # (c_o, c_i, h, w) -> (h, w, c_i, c_o)
-                   2 : (1, 0)}       # (c_o, c_i) -> (c_i, c_o)
+        mapping = {4: (2, 3, 1, 0),  # (c_o, c_i, h, w) -> (h, w, c_i, c_o)
+                   2: (1, 0)}       # (c_o, c_i) -> (c_i, c_o)
         DataReshaper(mapping).reshape(self.graph)
-        return {node.name:node.data for node in self.graph.nodes if node.data}
+        return {node.name: node.data for node in self.graph.nodes if node.data}
 
     def transform_source(self):
         if self.source is None:

--- a/test.py
+++ b/test.py
@@ -7,6 +7,7 @@ import numpy as np
 import tensorflow as tf
 import examples
 
+
 class ImageNet(object):
     def __init__(self, val_path, data_path, model):
         gt_lines = open(val_path).readlines()
@@ -48,16 +49,17 @@ class ImageNet(object):
     def __len__(self):
         return len(self.labels)
 
+
 def test_imagenet(model, data_path, val_path, images_path, top_k=5):
-    test_data   = tf.placeholder(tf.float32, shape=(model.batch_size, model.crop_size, model.crop_size, model.channels))
+    test_data = tf.placeholder(tf.float32, shape=(model.batch_size, model.crop_size, model.crop_size, model.channels))
     test_labels = tf.placeholder(tf.int32, shape=(model.batch_size,))
-    net         = model.net_class({'data':test_data})
-    probs       = net.get_output()
-    top_k_op    = tf.nn.in_top_k(probs, test_labels, top_k)
-    imagenet    = ImageNet(val_path, images_path, model)
-    correct     = 0
-    count       = 0
-    total       = len(imagenet)
+    net = model.net_class({'data':test_data})
+    probs = net.get_output()
+    top_k_op = tf.nn.in_top_k(probs, test_labels, top_k)
+    imagenet = ImageNet(val_path, images_path, model)
+    correct = 0
+    count = 0
+    total = len(imagenet)
     with tf.Session() as sesh:
         net.load(data_path, sesh)
         for idx, (images, labels) in enumerate(imagenet.batches(model.batch_size)):
@@ -67,13 +69,14 @@ def test_imagenet(model, data_path, val_path, images_path, top_k=5):
             print('{:>6}/{:<6} {:>6.2f}%'.format(count, total, cur_accuracy))
     print('Top %s Accuracy: %s'%(top_k, float(correct)/total))
 
+
 def main():
     args = sys.argv[1:]
     if len(args) not in (3, 4):
         print('usage: %s net.params imagenet-val.txt imagenet-data-dir [model-index=0]'%os.path.basename(__file__))
         exit(-1)
-    model_index = 0 if len(args)==3 else int(args[3])
-    if model_index>=len(examples.MODELS):
+    model_index = 0 if len(args) == 3 else int(args[3])
+    if model_index >= len(examples.MODELS):
         print('Invalid model index. Options are:')
         for idx, model in enumerate(examples.MODELS):
             print('%s: %s'%(idx, model))

--- a/test.py
+++ b/test.py
@@ -22,7 +22,7 @@ class ImageNet(object):
         h, w, c = np.shape(img)
         scale_size = self.model.scale_size
         crop_size = self.model.crop_size
-        assert c==3
+        assert c == 3
         if self.model.isotropic:
             aspect = float(w)/h
             if w<h:
@@ -79,10 +79,10 @@ def main():
     if model_index >= len(examples.MODELS):
         print('Invalid model index. Options are:')
         for idx, model in enumerate(examples.MODELS):
-            print('%s: %s'%(idx, model))
+            print('%s: %s' % (idx, model))
         exit(-1)  
     model = examples.MODELS[model_index]
-    print('Using model: %s'%(model))
+    print('Using model: %s' % (model))
     test_imagenet(model, *args[:3])
 
 if __name__ == '__main__':


### PR DESCRIPTION
**DO NOT MERGE YET**

Implementation of all the necessary functions in order to be able to convert FCNs models from Caffe to TensorFlow.
- [x] Implement correct shapes for deconvolution layer
- [x] Implement correct shapes for crop layer
- [x] Implement correct source generation for deconvolution layer
- [ ] Implement correct source generation for crop layer
- [x] Implement deconvolution layer in `kaffe.tensorflow.network.py`
- [ ] Implement crop layer in `kaffe.tensorflow.network.py`
- [ ] Make run protobuf version (version that does not need caffe)
- [ ] Clean code
